### PR TITLE
Fix last piece of "manual" avatar code, etc.

### DIFF
--- a/addons/godot-xr-avatar/scripts/automated_avatar.gd
+++ b/addons/godot-xr-avatar/scripts/automated_avatar.gd
@@ -317,22 +317,11 @@ func _ready():
 	right_target_transform.rotation_degrees.y = right_foot.rotation_degrees.y + $Armature/Skeleton.rotation_degrees.y
 	right_target_transform.rotation_degrees.z = right_foot.rotation_degrees.z + + $Armature/Skeleton.rotation_degrees.z
 	
-	
 	#Set skeleton targets to the automatically generated target nodes
-	if left_controller_path != null:
-		SkeletonIKL.set_target_node(NodePath("../../../../" + left_controller.name + "/" + left_hand.name + "/left_target"))
-	else:
-		print("Left controller path not found, assuming just using hand node.")
-		SkeletonIKL.set_target_node(NodePath("../../../../" + left_hand.name + "/left_target"))
-	
-	if right_controller_path != null:
-		SkeletonIKR.set_target_node(NodePath("../../../../" + right_controller.name + "/" + right_hand.name + "/right_target"))
-	else:
-		print("Right controller path not found, assuming just using hand node.")
-		SkeletonIKR.set_target_node(NodePath("../../../../" + right_hand.name + "/right_target"))
-	
-	SkeletonIKLegL.set_target_node(NodePath("../../../LL_c/LL_t"))
-	SkeletonIKLegR.set_target_node(NodePath("../../../RL_c/Rl_t"))
+	SkeletonIKL.set_target_node(left_hand_target.get_path())
+	SkeletonIKR.set_target_node(right_hand_target.get_path())
+	SkeletonIKLegL.set_target_node(left_target_transform.get_path())
+	SkeletonIKLegR.set_target_node(right_target_transform.get_path())
 	
 	#set other used variables in IK
 	RL_dB = left_target.transform.basis
@@ -423,7 +412,7 @@ func _ready():
 	# Calculate the body direction (in origin-space) from the head forward direction
 	body_direction = Plane.PLANE_XZ.project(arvrcamera.transform.basis.z).normalized()
 
-		
+
 #function use to place avatar feet on surfaces procedurally
 func update_ik_anim(target: Spatial, raycast: RayCast, bone_attach: BoneAttachment, d_b: Basis, avatar_height: float, hit_offset: float) -> void:
 	var bone_pos = bone_attach.global_transform.origin

--- a/addons/godot-xr-avatar/scripts/automated_shadow_parent.gd
+++ b/addons/godot-xr-avatar/scripts/automated_shadow_parent.gd
@@ -332,22 +332,11 @@ func _ready():
 	right_target_transform.rotation_degrees.y = right_foot.rotation_degrees.y + $FPController/avatar/Armature/Skeleton.rotation_degrees.y
 	right_target_transform.rotation_degrees.z = right_foot.rotation_degrees.z + + $FPController/avatar/Armature/Skeleton.rotation_degrees.z
 	
-	
 	#Set skeleton targets to the automatically generated target nodes
-	if player_left_controller_path != null:
-		SkeletonIKL.set_target_node(NodePath("../../../../" + left_controller.name + "/" + left_hand.name + "/left_target"))
-	else:
-		print("Left controller path not found, assuming just using hand node.")
-		SkeletonIKL.set_target_node(NodePath("../../../../" + left_hand.name + "/left_target"))
-	
-	if player_right_controller_path != null:
-		SkeletonIKR.set_target_node(NodePath("../../../../" + right_controller.name + "/" + right_hand.name + "/right_target"))
-	else:
-		print("Right controller path not found, assuming just using hand node.")
-		SkeletonIKR.set_target_node(NodePath("../../../../" + right_hand.name + "/right_target"))
-	
-	SkeletonIKLegL.set_target_node(NodePath("../../../LL_c/LL_t"))
-	SkeletonIKLegR.set_target_node(NodePath("../../../RL_c/Rl_t"))
+	SkeletonIKL.set_target_node(left_hand_target.get_path())
+	SkeletonIKR.set_target_node(right_hand_target.get_path())
+	SkeletonIKLegL.set_target_node(left_target_transform.get_path())
+	SkeletonIKLegR.set_target_node(right_target_transform.get_path())
 	
 	#set other used variables
 	RL_dB = left_target.transform.basis
@@ -366,8 +355,6 @@ func _ready():
 	Raycast_R.enabled = true
 	Raycast_R.cast_to = Vector3(0,-4,0)
 	
-	
-	
 	#set shadow avatar node transforms
 	if player_left_controller_path != null:
 		$FPController/LeftHandController.transform = get_left_controller_transform()
@@ -385,7 +372,6 @@ func _ready():
 	SkeletonIKR.start()
 	SkeletonIKLegL.start()
 	SkeletonIKLegR.start()
-	
 	
 	#if player chose to use LipSync in the export variables, create LipSync node
 	if use_automated_lipsync == true:

--- a/dojo_core/managers/HapticManager.gd
+++ b/dojo_core/managers/HapticManager.gd
@@ -16,8 +16,7 @@ func _ready():
 	right_controller = ARVRHelpers.get_right_controller(arvrorigin)
 	left_controller.get_node("Function_Pickup").connect("has_picked_up", self, "left_haptic_pulse_on_pickup")
 	right_controller.get_node("Function_Pickup").connect("has_picked_up", self, "right_haptic_pulse_on_pickup")
-	left_controller.connect("button_pressed", self, "left_haptic_pulse_on_button")
-	right_controller.connect("button_pressed", self, "right_haptic_pulse_on_button")
+
 
 func left_haptic_pulse_on_pickup(_what):
 	left_controller.set_rumble(0.2)


### PR DESCRIPTION
-Have learned about get_path() function to get the NodePath of a node since original coding of automatedavatar.gd.  Before we had to hard code the node path of the targets for the SkeletonIK, which created potential issues for errors. Now the Nodepath is automatically generated from the automatic IK targets.  I think in theory this should make it easier for making the avatar a "puppet" disconnected from the FP Controller because dev would not have to worry about the manual path dependency in the code (example, code would fail if avatar body was placed under a node other than FPController due to the manual nodepath).

-Also fixed haptic manager errors in test scene.